### PR TITLE
Allow setting of EnablePrivateCluster in AKS

### DIFF
--- a/apis/compute/v1alpha3/types.go
+++ b/apis/compute/v1alpha3/types.go
@@ -81,6 +81,10 @@ type AKSClusterParameters struct {
 	// cluster.
 	// +optional
 	DisableRBAC bool `json:"disableRBAC,omitempty"`
+	// EnablePrivateCluster determines whether the cluster will be created as a private cluster
+	// default false
+	// +optional
+	EnablePrivateCluster bool `json:"enablePrivateCluster,omitempty"`
 }
 
 // An AKSClusterSpec defines the desired state of a AKSCluster.

--- a/examples/compute/akscluster.yaml
+++ b/examples/compute/akscluster.yaml
@@ -16,6 +16,7 @@ spec:
   nodeVMSize: Standard_B2s
   dnsNamePrefix: crossplane-aks
   disableRBAC: false
+  enablePrivateCluster: false
   providerConfigRef:
     name: example
   writeConnectionSecretToRef:

--- a/package/crds/compute.azure.crossplane.io_aksclusters.yaml
+++ b/package/crds/compute.azure.crossplane.io_aksclusters.yaml
@@ -75,6 +75,10 @@ spec:
                   to the Kubernetes API when managing containers after creating the
                   cluster.
                 type: string
+              enablePrivateCluster:
+                description: EnablePrivateCluster determines whether the cluster will
+                  be created as a private cluster default false
+                type: boolean
               location:
                 description: Location is the Azure location that the cluster will
                   be created in

--- a/pkg/clients/compute/aks.go
+++ b/pkg/clients/compute/aks.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/authorization/mgmt/2015-07-01/authorization"
 	authorizationmgmt "github.com/Azure/azure-sdk-for-go/services/authorization/mgmt/2015-07-01/authorization"
-	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2018-03-31/containerservice"
+	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2019-11-01/containerservice"
 	"github.com/Azure/azure-sdk-for-go/services/graphrbac/1.6/graphrbac"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/adal"
@@ -288,11 +288,16 @@ func newManagedCluster(c *v1alpha3.AKSCluster, appID, secret string) containerse
 				Secret:   to.StringPtr(secret),
 			},
 			EnableRBAC: to.BoolPtr(!c.Spec.DisableRBAC),
+			APIServerAccessProfile: &containerservice.ManagedClusterAPIServerAccessProfile{
+				EnablePrivateCluster: to.BoolPtr(c.Spec.EnablePrivateCluster),
+			},
 		},
 	}
 
 	if c.Spec.VnetSubnetID != "" {
-		p.ManagedClusterProperties.NetworkProfile = &containerservice.NetworkProfile{NetworkPlugin: containerservice.Azure}
+		p.ManagedClusterProperties.NetworkProfile = &containerservice.NetworkProfileType{
+			NetworkPlugin: containerservice.Azure,
+		}
 		p.ManagedClusterProperties.AgentPoolProfiles = &[]containerservice.ManagedClusterAgentPoolProfile{
 			{
 				Name:         to.StringPtr(AgentPoolProfileName),

--- a/pkg/clients/compute/fake/fake.go
+++ b/pkg/clients/compute/fake/fake.go
@@ -19,7 +19,7 @@ package fake
 import (
 	"context"
 
-	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2018-03-31/containerservice"
+	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2019-11-01/containerservice"
 
 	"github.com/crossplane-contrib/provider-azure/apis/compute/v1alpha3"
 )

--- a/pkg/controller/compute/managed_test.go
+++ b/pkg/controller/compute/managed_test.go
@@ -21,7 +21,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2018-03-31/containerservice"
+	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2019-11-01/containerservice"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/to"
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"


### PR DESCRIPTION
created new AKSClusterParameters EnablePrivateCluster optional field.
updated akscluster.yml example to add in new field
updated containerservice api to be set to 2019-11-01 when the private cluster option became available.
Added in APIServerAccessProfile config to ManagedClusterProperties to enable private cluster.
Updated NetworkProfile configuration to meet new requirement of NetworkProfileType.NetworkPlugin
Updated all instances of containerservice api to 2019-11-01
Signed-off-by: Craviotto, Kyle <Kyle.Craviotto@LibertyMutual.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
Enables setting of the [EnablePrivateCluster](https://github.com/Azure/azure-sdk-for-go/blob/v61.0.0/services/containerservice/mgmt/2020-11-01/containerservice/models.go#L1253) in the ManagedClusterAPIServerAccessProfile configuration option for ManagedClusterProperties.
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #235 

I have:

- [ x] Read and followed Crossplane's [contribution process].
- [ x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
ran the process of make reviewable test
[contribution process]: https://git.io/fj2m9
